### PR TITLE
Adding support for WebP image

### DIFF
--- a/class-gktpp-insert-to-db.php
+++ b/class-gktpp-insert-to-db.php
@@ -92,6 +92,7 @@ class GKTPP_Insert_To_DB {
 			case '.jpeg':
 			case '.png':
 			case '.svg':
+			case '.webp':
 				$this->as_attr = 'image';
 				break;
 			case '.vtt':


### PR DESCRIPTION
Currently `as` attribute isn't added for WebP format images